### PR TITLE
Bug: Going in landscape mode causes the application to crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,9 @@
         <activity
             android:name=".ui.activity.MainActivity"
             android:exported="true"
-            android:hardwareAccelerated="true">
+            android:hardwareAccelerated="true"
+            android:configChanges="orientation"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fix the bug where going into landscape mode causes the app to crash with the following stack trace.

Exception java.lang.RuntimeException:
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:4880)
  at android.app.ActivityThread.-$$Nest$mhandleServiceArgs
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2314)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:205)
  at android.os.Looper.loop (Looper.java:294)
  at android.app.ActivityThread.main (ActivityThread.java:8248)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:552)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:971)
Caused by java.lang.IllegalStateException: The session token has already been set
  at androidx.media.MediaBrowserServiceCompat.setSessionToken (MediaBrowserServiceCompat.java:1472)
  at com.aaa.vibesmusic.player.MediaPlayerService.initMediaPlayer (MediaPlayerService.java:204)
  at com.aaa.vibesmusic.player.MediaPlayerService.onStartCommand (MediaPlayerService.java:423)
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:4862)